### PR TITLE
Fix UnsupportedOperationException from OperationBuilders

### DIFF
--- a/src/main/java/com/kentyou/featurelauncher/impl/runtime/FeatureRuntimeImpl.java
+++ b/src/main/java/com/kentyou/featurelauncher/impl/runtime/FeatureRuntimeImpl.java
@@ -242,7 +242,7 @@ public class FeatureRuntimeImpl extends ArtifactRepositoryFactoryImpl implements
 			this.feature = feature;
 			this.isCompleted = false;
 			this.useDefaultRepositories = true;
-			this.artifactRepositories = getDefaultRepositories();
+			this.artifactRepositories = new HashMap<>();
 			this.variables = new HashMap<>();
 			this.decorators = new ArrayList<>();
 			this.extensionHandlers = new HashMap<>();
@@ -259,8 +259,6 @@ public class FeatureRuntimeImpl extends ArtifactRepositoryFactoryImpl implements
 
 			ensureNotCompletedYet();
 
-			maybeResetDefaultRepositories();
-
 			this.artifactRepositories.put(name, repository);
 
 			return castThis();
@@ -275,8 +273,6 @@ public class FeatureRuntimeImpl extends ArtifactRepositoryFactoryImpl implements
 			ensureNotCompletedYet();
 
 			this.useDefaultRepositories = include;
-
-			maybeResetDefaultRepositories();
 
 			return castThis();
 		}
@@ -364,6 +360,11 @@ public class FeatureRuntimeImpl extends ArtifactRepositoryFactoryImpl implements
 		@Override
 		public InstalledFeature complete() throws FeatureRuntimeException {
 			this.isCompleted = true;
+
+			if(this.useDefaultRepositories) {
+				getDefaultRepositories().forEach(
+						(k,v) -> this.artifactRepositories.putIfAbsent(k, v));
+			}
 
 			return addOrUpdateFeature(feature);
 		}
@@ -584,12 +585,6 @@ public class FeatureRuntimeImpl extends ArtifactRepositoryFactoryImpl implements
 				throw new FeatureRuntimeException(
 						String.format("The feature %d has mandatory extensions for which are not understood",
 								unknownMandatoryFeatureExtensions.size()));
-			}
-		}
-
-		private void maybeResetDefaultRepositories() {
-			if (!this.useDefaultRepositories) {
-				this.artifactRepositories = new HashMap<>();
 			}
 		}
 

--- a/src/test/java/com/kentyou/featurelauncher/impl/runtime/integration/FeatureRuntimeIntegrationTest.java
+++ b/src/test/java/com/kentyou/featurelauncher/impl/runtime/integration/FeatureRuntimeIntegrationTest.java
@@ -39,6 +39,8 @@ import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -176,8 +178,9 @@ public class FeatureRuntimeIntegrationTest {
 		}
 	}
 
-	@Test
-	public void testInstallFeatureWithNoConfigWithCustomRepositories(
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	public void testInstallFeatureWithNoConfigWithCustomRepositories(boolean useDefault,
 			@InjectService(cardinality = 1, timeout = 5000) ServiceAware<FeatureRuntime> featureRuntimeServiceAware)
 			throws URISyntaxException, IOException {
 		assertEquals(1, featureRuntimeServiceAware.getServices().size());
@@ -201,7 +204,7 @@ public class FeatureRuntimeIntegrationTest {
 			// Install Feature using default repositories
 			// @formatter:off
 			InstalledFeature installedFeature = featureRuntimeService.install(featureReader)
-					.useDefaultRepositories(false)
+					.useDefaultRepositories(useDefault)
 					.addRepository("local", localArtifactRepository)
 					.addRepository("central", remoteRepository)
 					.install();


### PR DESCRIPTION
When registering artifact repositories with an Operation Builder the user gets an UnsupportedOperationException if the builder is using default repositories. Furthermore, setting useDefaultRepositories causes any previously registered repositories to be lost. This should be fixed to ensure that no registered repositories are lost, and that default repositories are only used if enabled and not overriden in the builder.