### PR TITLE
Refactor framework location

### DIFF
--- a/src/main/java/com/kentyou/featurelauncher/impl/FeatureLauncherImpl.java
+++ b/src/main/java/com/kentyou/featurelauncher/impl/FeatureLauncherImpl.java
@@ -109,7 +109,7 @@ public class FeatureLauncherImpl extends ArtifactRepositoryFactoryImpl implement
 	}
 
 	class LaunchBuilderImpl implements LaunchBuilder {
-		private final DecorationUtil decorationUtil = new DecorationUtil();
+		private DecorationUtil decorationUtil;
 		private Feature feature;
 		private boolean isLaunched;
 		private List<Bundle> installedBundles;
@@ -243,6 +243,8 @@ public class FeatureLauncherImpl extends ArtifactRepositoryFactoryImpl implement
 			ensureNotLaunchedYet();
 
 			this.isLaunched = true;
+			
+			decorationUtil = new DecorationUtil(this.artifactRepositories);
 
 			//////////////////////////////////////
 			// 160.4.3.1: Feature Decoration

--- a/src/main/java/com/kentyou/featurelauncher/impl/FrameworkFactoryLocator.java
+++ b/src/main/java/com/kentyou/featurelauncher/impl/FrameworkFactoryLocator.java
@@ -13,8 +13,6 @@
  */
 package com.kentyou.featurelauncher.impl;
 
-import static org.osgi.service.featurelauncher.FeatureLauncherConstants.LAUNCH_FRAMEWORK;
-
 import java.lang.StackWalker.StackFrame;
 import java.util.List;
 import java.util.Optional;
@@ -50,8 +48,8 @@ class FrameworkFactoryLocator {
 		 * can be found in any configured Artifact Repositories, as described in
 		 * Selecting a framework implementation on page 99"
 		 */
-		Optional<FrameworkFactory> selectFrameworkFactoryOptional = selectFrameworkFactory(feature,
-				decorationUtil, artifactRepositories);
+		Optional<FrameworkFactory> selectFrameworkFactoryOptional = decorationUtil
+				.getLaunchHandler().getLocatedFrameworkFactory();
 		if (selectFrameworkFactoryOptional.isPresent()) {
 			return selectFrameworkFactoryOptional.get();
 		}
@@ -80,13 +78,6 @@ class FrameworkFactoryLocator {
 		} else {
 			throw new LaunchException("Error loading default framework factory!");
 		}
-	}
-
-	private static Optional<FrameworkFactory> selectFrameworkFactory(Feature feature,
-			DecorationUtil decorationUtil, List<ArtifactRepository> artifactRepositories) {
-		return decorationUtil.getLaunchHandler()
-				.selectFrameworkFactory(feature.getExtensions().get(LAUNCH_FRAMEWORK),
-						artifactRepositories, loadDefaultFrameworkFactory());
 	}
 
 	private static Optional<FrameworkFactory> findFrameworkFactory() {

--- a/src/main/java/com/kentyou/featurelauncher/impl/decorator/LaunchFrameworkFeatureExtensionHandlerImpl.java
+++ b/src/main/java/com/kentyou/featurelauncher/impl/decorator/LaunchFrameworkFeatureExtensionHandlerImpl.java
@@ -13,21 +13,24 @@
  */
 package com.kentyou.featurelauncher.impl.decorator;
 
-import java.net.MalformedURLException;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
-import java.util.ServiceLoader;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 
 import org.osgi.framework.launch.FrameworkFactory;
 import org.osgi.service.feature.Feature;
 import org.osgi.service.feature.FeatureArtifact;
 import org.osgi.service.feature.FeatureExtension;
+import org.osgi.service.feature.FeatureExtension.Type;
 import org.osgi.service.feature.ID;
-import org.osgi.service.featurelauncher.LaunchException;
 import org.osgi.service.featurelauncher.decorator.AbandonOperationException;
 import org.osgi.service.featurelauncher.decorator.DecoratorBuilderFactory;
 import org.osgi.service.featurelauncher.decorator.FeatureExtensionHandler;
@@ -47,6 +50,17 @@ import com.kentyou.featurelauncher.impl.util.DecorationUtil;
 public class LaunchFrameworkFeatureExtensionHandlerImpl implements FeatureExtensionHandler {
 	private static final Logger LOG = LoggerFactory.getLogger(LaunchFrameworkFeatureExtensionHandlerImpl.class);
 
+	private static final String FF_SERVICE_PATH = "META-INF/services/org.osgi.framework.launch.FrameworkFactory";
+	
+	private final List<? extends ArtifactRepository> artifactRepositories;
+	
+	private Optional<FrameworkFactory> locatedFramework = Optional.empty();
+
+	public LaunchFrameworkFeatureExtensionHandlerImpl(List<? extends ArtifactRepository> artifactRepositories) {
+		super();
+		this.artifactRepositories = artifactRepositories;
+	}
+
 	/* 
 	 * (non-Javadoc)
 	 * @see org.osgi.service.featurelauncher.decorator.FeatureExtensionHandler#handle(org.osgi.service.feature.Feature, org.osgi.service.feature.FeatureExtension, org.osgi.service.featurelauncher.decorator.FeatureExtensionHandler.FeatureExtensionHandlerBuilder, org.osgi.service.featurelauncher.decorator.DecoratorBuilderFactory)
@@ -55,68 +69,99 @@ public class LaunchFrameworkFeatureExtensionHandlerImpl implements FeatureExtens
 	public Feature handle(Feature feature, FeatureExtension extension,
 			FeatureExtensionHandlerBuilder decoratedFeatureBuilder, DecoratorBuilderFactory factory)
 			throws AbandonOperationException {
-		return feature;
-	}
-
-	public Optional<FrameworkFactory> selectFrameworkFactory(FeatureExtension featureExtension,
-			List<ArtifactRepository> artifactRepositories, Optional<FrameworkFactory> defaultFrameworkFactoryOptional) {
-		Optional<FrameworkFactory> selectFrameworkFactoryOptional = Optional.empty();
-
-		if(featureExtension == null) {
-			return selectFrameworkFactoryOptional;
+		
+		if(extension.getType() != Type.ARTIFACTS) {
+			throw new AbandonOperationException("The Launch extension was not of type ARTIFACTS");
 		}
 		
-		for (FeatureArtifact featureArtifact : featureExtension.getArtifacts()) {
-			Path artifactPath = getArtifactPath(featureArtifact.getID(), artifactRepositories);
-
-			URL artifactJarFileURL = constructArtifactJarFileURL(artifactPath);
-
-			try {
-
-				URLClassLoader urlClassLoader = URLClassLoader.newInstance(new URL[] { artifactJarFileURL },
-						Thread.currentThread().getContextClassLoader());
-
-				ServiceLoader<FrameworkFactory> serviceLoader = ServiceLoader.load(FrameworkFactory.class,
-						urlClassLoader);
-
-				// @formatter:off
-				List<FrameworkFactory> loadedServices = serviceLoader.stream()
-						.map(p -> p.get())
-						.collect(Collectors.toList());
-				// @formatter:on
-
-				if (defaultFrameworkFactoryOptional.isPresent() && loadedServices.size() > 1) {
-					// @formatter:off
-					loadedServices.stream()
-						.filter(ff -> (ff.getClass().isInstance(defaultFrameworkFactoryOptional.get())))
-						.findFirst()
-						.ifPresent(loadedServices::remove);
-					// @formatter:on
-				}
-
-				selectFrameworkFactoryOptional = Optional.of(loadedServices.get(0));
-
-				if (selectFrameworkFactoryOptional.isPresent()) {
-					LOG.info(String.format("Selected '%s' OSGi framework implementation",
-							selectFrameworkFactoryOptional.get()));
-					Thread.currentThread().setContextClassLoader(urlClassLoader);
-					break;
-				} else {
-					urlClassLoader.close();
-				}
-			} catch (Throwable t) {
-				LOG.warn(String.format("'%s' is not an OSGi framework implementation!", featureArtifact.getID()), t);
+		for (FeatureArtifact featureArtifact : extension.getArtifacts()) {
+			locatedFramework = findFrameworkFactory(featureArtifact);
+			if(locatedFramework.isPresent()) {
+				break;
 			}
 		}
 		
-		if(selectFrameworkFactoryOptional.isEmpty() && DecorationUtil.isExtensionMandatory(featureExtension)) {
-			throw new LaunchException("No suitable OSGi framework implementation could be selected!");
+		if(locatedFramework.isEmpty() && DecorationUtil.isExtensionMandatory(extension)) {
+			throw new AbandonOperationException("No suitable OSGi framework implementation could be selected for the mandatory launch extension!");
 		}
-
-		return selectFrameworkFactoryOptional;
+		
+		return feature;
 	}
 
-	private Path getArtifactPath(ID artifactId, List<ArtifactRepository> artifactRepositories) {
+	public Optional<FrameworkFactory> getLocatedFrameworkFactory() {
+		return locatedFramework;
+	}
+		
+	private Optional<FrameworkFactory> findFrameworkFactory(FeatureArtifact featureArtifact) {
+		Path artifactPath = getArtifactPath(featureArtifact.getID(), artifactRepositories);
+		
+		if(artifactPath == null) {
+			LOG.debug("Unable to find the framework artifact {}", featureArtifact.getID());
+			return Optional.empty();
+		}
+
+		// We don't use service loader as we want to target exactly this one artifact file
+		try (JarFile jar = new JarFile(artifactPath.toFile())) {
+			JarEntry je = jar.getJarEntry(FF_SERVICE_PATH);
+			if(je == null) {
+				LOG.warn("The framework artifact {} did not declare a FrameworkFactory service file", featureArtifact.getID());
+				return Optional.empty();
+			}
+			List<String> classNames;
+			try(BufferedReader br = new BufferedReader(new InputStreamReader(jar.getInputStream(je), StandardCharsets.UTF_8))) {
+				classNames = br.lines().collect(Collectors.toList());
+			}
+			
+			if(classNames.isEmpty()) {
+				LOG.warn("The framework artifact {} did not declare any FrameworkFactory services", featureArtifact.getID());
+				return Optional.empty();
+			}
+			
+			URLClassLoader urlClassLoader = URLClassLoader.newInstance(
+					new URL[] { artifactPath.toUri().toURL() },
+						getClass().getClassLoader());
+			
+			
+			for(String className : classNames) {
+				Class<?> clz;
+				try {
+					clz = urlClassLoader.loadClass(className);
+				} catch (Exception e) {
+					LOG.warn("Unable to load factory class {} for the framework artifact {}.", 
+							className, featureArtifact.getID(), e);
+					continue;
+				}
+				
+				if(FrameworkFactory.class.isAssignableFrom(clz)) {
+					FrameworkFactory ff;
+					try {
+						ff = (FrameworkFactory) clz.getConstructor().newInstance();
+					} catch (Exception e) {
+						LOG.warn("The factory class {} for the framework artifact {} could not be instantiated.", 
+								className, featureArtifact.getID());
+						continue;
+					}
+					if(LOG.isDebugEnabled()) {
+						LOG.debug("Found Framework Factory {} from artifact {}", className, featureArtifact.getID());
+					}
+					return Optional.of(ff);
+				} else {
+					LOG.warn("The factory class {} for the framework artifact {} was not a FrameworkFactory.", 
+							className, featureArtifact.getID());
+					continue;
+				}
+			}
+		} catch (Exception e1) {
+			LOG.warn("Failed to discover a framework factory from artifact {}",
+					featureArtifact.getID(), e1);
+		}
+		if(LOG.isDebugEnabled()) {
+			LOG.debug("No Framework Factory found in artifact {}", featureArtifact.getID());
+		}
+		return Optional.empty();
+	}
+
+	private Path getArtifactPath(ID artifactId, List<? extends ArtifactRepository> artifactRepositories) {
 		for (ArtifactRepository artifactRepository : artifactRepositories) {
 			Path artifactPath = ((FileSystemArtifactRepository) artifactRepository).getArtifactPath(artifactId);
 			if (artifactPath != null) {
@@ -125,13 +170,5 @@ public class LaunchFrameworkFeatureExtensionHandlerImpl implements FeatureExtens
 		}
 
 		return null;
-	}
-
-	private URL constructArtifactJarFileURL(Path jarFilePath) {
-		try {
-			return jarFilePath.toUri().toURL();
-		} catch (MalformedURLException e) {
-			throw new RuntimeException("Error constructing URL for JAR artifact!", e);
-		}
 	}
 }

--- a/src/main/java/com/kentyou/featurelauncher/impl/runtime/FeatureRuntimeImpl.java
+++ b/src/main/java/com/kentyou/featurelauncher/impl/runtime/FeatureRuntimeImpl.java
@@ -252,7 +252,7 @@ public class FeatureRuntimeImpl extends ArtifactRepositoryFactoryImpl implements
 	}
 
 	abstract class AbstractOperationBuilderImpl<T extends OperationBuilder<T>> implements OperationBuilder<T> {
-		protected final DecorationUtil decorationUtil = new DecorationUtil();
+		protected DecorationUtil decorationUtil;
 		protected Feature feature;
 		protected boolean isCompleted;
 		protected boolean useDefaultRepositories;
@@ -391,6 +391,8 @@ public class FeatureRuntimeImpl extends ArtifactRepositoryFactoryImpl implements
 			if (this.useDefaultRepositories) {
 				getDefaultRepositories().forEach((k, v) -> this.artifactRepositories.putIfAbsent(k, v));
 			}
+
+			decorationUtil = new DecorationUtil(List.copyOf(this.artifactRepositories.values()));
 
 			return addOrUpdateFeature(feature);
 		}

--- a/src/main/java/com/kentyou/featurelauncher/impl/util/DecorationUtil.java
+++ b/src/main/java/com/kentyou/featurelauncher/impl/util/DecorationUtil.java
@@ -28,6 +28,7 @@ import org.osgi.service.feature.FeatureService;
 import org.osgi.service.featurelauncher.decorator.AbandonOperationException;
 import org.osgi.service.featurelauncher.decorator.FeatureDecorator;
 import org.osgi.service.featurelauncher.decorator.FeatureExtensionHandler;
+import org.osgi.service.featurelauncher.repository.ArtifactRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,17 +57,21 @@ public class DecorationUtil {
 
 	private static final Logger LOG = LoggerFactory.getLogger(DecorationUtil.class);
 	
-	private final LaunchFrameworkFeatureExtensionHandlerImpl launchHandler = new LaunchFrameworkFeatureExtensionHandlerImpl();
+	private final LaunchFrameworkFeatureExtensionHandlerImpl launchHandler;
 	private final FrameworkLaunchingPropertiesFeatureExtensionHandlerImpl frameworkHandler = new FrameworkLaunchingPropertiesFeatureExtensionHandlerImpl();
 	private final BundleStartLevelsFeatureExtensionHandlerImpl startLevelHandler = new BundleStartLevelsFeatureExtensionHandlerImpl();
-	
-	// @formatter:off
-	private final Map<String, FeatureExtensionHandler> handlers = Map.ofEntries(
-			Map.entry(LAUNCH_FRAMEWORK, launchHandler),
-			Map.entry(FRAMEWORK_LAUNCHING_PROPERTIES, frameworkHandler),
-			Map.entry(BUNDLE_START_LEVELS, startLevelHandler));
-	// @formatter:on
+	private final Map<String, FeatureExtensionHandler> handlers;
 
+	public DecorationUtil(List<? extends ArtifactRepository> repositories) {
+		launchHandler = new LaunchFrameworkFeatureExtensionHandlerImpl(repositories);
+		// @formatter:off
+		handlers = Map.ofEntries(
+				Map.entry(LAUNCH_FRAMEWORK, launchHandler),
+				Map.entry(FRAMEWORK_LAUNCHING_PROPERTIES, frameworkHandler),
+				Map.entry(BUNDLE_START_LEVELS, startLevelHandler));
+		// @formatter:on
+	}
+	
 	public LaunchFrameworkFeatureExtensionHandlerImpl getLaunchHandler() {
 		return launchHandler;
 	}

--- a/src/test/java/com/kentyou/featurelauncher/impl/FeatureLauncherImplTest.java
+++ b/src/test/java/com/kentyou/featurelauncher/impl/FeatureLauncherImplTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
+import org.osgi.framework.Version;
 import org.osgi.framework.launch.Framework;
 import org.osgi.framework.startlevel.FrameworkStartLevel;
 import org.osgi.service.featurelauncher.FeatureLauncher;
@@ -252,6 +253,9 @@ public class FeatureLauncherImplTest {
 		Bundle[] bundles = osgiFramework.getBundleContext().getBundles();
 		assertEquals(15, bundles.length);
 
+		assertEquals("org.apache.felix.framework", bundles[0].getSymbolicName());
+		assertEquals(Version.parseVersion("7.0.5"), bundles[0].getVersion());
+
 		assertEquals("org.apache.felix.configadmin", bundles[1].getSymbolicName());
 		assertEquals("ACTIVE", BundleStateUtil.getBundleStateString(bundles[1].getState()));
 
@@ -295,6 +299,9 @@ public class FeatureLauncherImplTest {
 		// Verify bundles defined in feature are installed and started
 		Bundle[] bundles = osgiFramework.getBundleContext().getBundles();
 		assertEquals(4, bundles.length);
+
+		assertEquals("org.eclipse.osgi", bundles[0].getSymbolicName());
+		assertEquals(Version.parseVersion("3.21.0.v20240717-2103"), bundles[0].getVersion());
 
 		assertEquals("org.apache.felix.gogo.command", bundles[1].getSymbolicName());
 		assertEquals("ACTIVE", BundleStateUtil.getBundleStateString(bundles[1].getState()));

--- a/src/test/java/com/kentyou/featurelauncher/impl/decorator/FeatureDecoratorImplTest.java
+++ b/src/test/java/com/kentyou/featurelauncher/impl/decorator/FeatureDecoratorImplTest.java
@@ -61,7 +61,7 @@ public class FeatureDecoratorImplTest {
 		featureService = ServiceLoaderUtil.loadFeatureService();
 		assertNotNull(featureService);
 
-		util = new DecorationUtil();
+		util = new DecorationUtil(List.of());
 
 		// Read feature
 		Path featureJSONPath = Paths.get(getClass().getResource("/features/gogo-console-feature.json").toURI());

--- a/src/test/java/com/kentyou/featurelauncher/impl/decorator/FeatureExtensionHandlerImplTest.java
+++ b/src/test/java/com/kentyou/featurelauncher/impl/decorator/FeatureExtensionHandlerImplTest.java
@@ -64,7 +64,7 @@ public class FeatureExtensionHandlerImplTest {
 		featureService = ServiceLoaderUtil.loadFeatureService();
 		assertNotNull(featureService);
 
-		util = new DecorationUtil();
+		util = new DecorationUtil(List.of());
 		
 		// Read feature
 		Path featureJSONPath = Paths


### PR DESCRIPTION
Framework location should be performed during extension processing where we have all the information we need. Also:

* Don't use ServiceLoader as we need to search the specific artifact, not the parent classloader
* Properly handle mandatory extensions